### PR TITLE
Improve handling of invalid user data

### DIFF
--- a/app/cyclid_ui/controllers/auth.rb
+++ b/app/cyclid_ui/controllers/auth.rb
@@ -51,8 +51,12 @@ module Cyclid
 
           # At this point the user has authenticated successfully; get the user
           # information; the User model will cache it automatically.
-          user = Models::User.get(username: username, password: password)
-          Cyclid.logger.debug "user=#{user.to_hash}"
+          begin
+            user = Models::User.get(username: username, password: password)
+            Cyclid.logger.debug "user=#{user.to_hash}"
+          rescue
+            halt_with_401
+          end
 
           # Store the username in the session
           session[:username] = username

--- a/app/cyclid_ui/models/user.rb
+++ b/app/cyclid_ui/models/user.rb
@@ -69,6 +69,9 @@ module Cyclid
 
           auth_method = token.nil? ? Client::AUTH_BASIC : Client::AUTH_TOKEN
 
+          # We must have one or the other
+          raise 'no password or token' if password.nil? and token.nil?
+
           user_data = nil
           begin
             Cyclid.logger.debug "api=#{Cyclid.config.server_api.inspect}"


### PR DESCRIPTION
Catch exceptions from the User model wherever we call it.
Ensure the JWT token has been deleted when the user is unauthenticated.
Ensure one of a password or a token have been given to the Users model before
passing them to the Cyclid client.