### PR TITLE
Split the cookie & session secret

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,9 @@ GIT
       spoon
 
 PATH
-  remote: ../Cyclid-client/
+  remote: ../Cyclid-client
   specs:
-    cyclid-client (0.3.3)
+    cyclid-client (0.3.4)
       bcrypt (~> 3.1)
       colorize (~> 0.7)
       cyclid-core (~> 0.1)
@@ -26,7 +26,7 @@ PATH
       thor (~> 0.19)
 
 PATH
-  remote: ../Cyclid-core/
+  remote: ../Cyclid-core
   specs:
     cyclid-core (0.1.1)
       rack (~> 1.6)
@@ -212,4 +212,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/app/cyclid_ui.rb
+++ b/app/cyclid_ui.rb
@@ -55,10 +55,13 @@ module Cyclid
     # Sinatra application
     class App < Sinatra::Application
       use Rack::Deflater
-      use Rack::Session::Cookie
-      use Rack::Csrf, raise: true,
-                      skip: ['POST:/login',
-                             'POST:/unauthenticated']
+      use Rack::Session::Pool,
+          expire_after: 31_557_600,
+          secret: ENV['COOKIE_SECRET'] || '8f54749dcb0ae0843cdd9669b797d311'
+      use Rack::Csrf,
+          raise: true,
+          skip: ['POST:/login',
+                 'POST:/unauthenticated']
 
       helpers Helpers
 
@@ -67,8 +70,7 @@ module Cyclid
       configure do
         set sessions: true,
             secure: production?,
-            expire_after: 31_557_600,
-            secret: ENV['SESSION_SECRET']
+            session_secret: ENV['SESSION_SECRET']
         set allow_origin: :any,
             allow_methods: [:get, :put, :post, :options],
             allow_credentials: true,


### PR DESCRIPTION
Use the SESSION_SECRET environment variable for the session, and COOKIE_SECRET
for other cookies.
Set a default value if COOKIE_SECRET isn't set, to ensure the JWT always has
some sort of hash with it.
Ensure session_secret is configured correctly.