### PR TITLE
Redirect to the original location after login

### DIFF
--- a/app/cyclid_ui.rb
+++ b/app/cyclid_ui.rb
@@ -133,6 +133,8 @@ module Cyclid
         # it sees the 401 response
         env['warden'].custom_failure!
         flash[:login_error] = 'Invalid username or password'
+        session[:request_uri] = env['REQUEST_URI'] \
+          unless session.key? :request_uri
         cookies.delete 'cyclid.token'
         redirect to '/login'
       end

--- a/app/cyclid_ui/controllers/auth.rb
+++ b/app/cyclid_ui/controllers/auth.rb
@@ -71,7 +71,11 @@ module Cyclid
           # Pick the first organization from the users membership and
           # redirect; if the user doesn't belong to any organizations,
           # redirect them to their user page
-          initial_page = if user.organizations.empty?
+          request_uri = session[:request_uri]
+          Cyclid.logger.debug "request_uri=#{request_uri}"
+          initial_page = if request_uri
+                           request_uri
+                         elsif user.organizations.empty?
                            "/user/#{username}"
                          else
                            user.organizations.first


### PR DESCRIPTION
If the user is following a direct URL, store it in the session and redirect
them back to the original location after successful login.