### PR TITLE
Add a user-invaldation endpoint

### DIFF
--- a/app/cyclid_ui.rb
+++ b/app/cyclid_ui.rb
@@ -61,7 +61,8 @@ module Cyclid
       use Rack::Csrf,
           raise: true,
           skip: ['POST:/login',
-                 'POST:/unauthenticated']
+                 'POST:/unauthenticated',
+                 'POST:/user/.*/invalidate']
 
       helpers Helpers
 

--- a/app/cyclid_ui/models/user.rb
+++ b/app/cyclid_ui/models/user.rb
@@ -90,6 +90,20 @@ module Cyclid
 
           user_data
         end
+
+        def self.invalidate(args)
+          username = args[:username] || args['username']
+          memcache = Memcache.new(server: Cyclid.config.memcached)
+          begin
+            user_fetch(args)
+            memcache.expire(username)
+          rescue Memcached::ServerIsMarkedDead => ex
+            Cyclid.logger.fatal "cannot connect to memcached: #{ex}"
+            # If Memcache is down there is nothing to expire
+          rescue StandardError => ex
+            Cyclid.logger.debug "user invalidate failed: #{ex}"
+          end
+        end
       end
     end
   end

--- a/public/js/job.js
+++ b/public/js/job.js
@@ -179,7 +179,7 @@ function ji_get_failed(xhr) {
   // the worst (cyclid.token is invalid) and force re-authentication, too.
   if(xhr.status == 401 || xhr.status == 0){
     console.log(`Failed to retrieve job list: status was ${xhr.status}`);
-    window.location = '/login';
+    window.location = '/';
   } else {
     var failure_message = `<p>
                              <h2>Failed to retrieve job</h2><br>

--- a/public/js/organization.js
+++ b/public/js/organization.js
@@ -76,7 +76,7 @@ function org_job_list_failed(xhr) {
   // the worst (cyclid.token is invalid) and force re-authentication, too.
   if(xhr.status == 401 || xhr.status == 0){
     console.log(`Failed to retrieve job list: status was ${xhr.status}`);
-    window.location = '/login';
+    window.location = '/';
   } else {
     var failure_message = `Failed to retrieve job list<br>
                            <strong>${xhr.status}:</strong> ${xhr.responseText}`;

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -10,7 +10,7 @@ function user_get_failed(xhr){
   // the worst (cyclid.token is invalid) and force re-authentication, too.
   if(xhr.status == 401 || xhr.status == 0){
     console.log(`Failed to retrieve job list: status was ${xhr.status}`);
-    window.location = '/login';
+    window.location = '/';
   } else {
     var failure_message = `Failed to retrieve user details<br>
                            <strong>${xhr.status}:</strong> ${xhr.responseText}`;


### PR DESCRIPTION
Add /user/:username/invalidate as an endpoint that will flush the user object
from Memcache. This can be used to force a refresh when the users organization
membership changes.
When client-side authentication fails (E.g. an AJAX request gets 401) redirect
to / and let the server handle things. If the user session itself is still
valid (E.g. the organization was deleted by the user is still logged in) then
it can redirect somewhere useful; if the user really is not authenticated then
it can handle session invalidation and redirect to /login: this may also fix
the problem of users getting stuck on the /login page when login redirection
fails.