### PR TITLE
Improve billing integration

### DIFF
--- a/app/cyclid_ui.rb
+++ b/app/cyclid_ui.rb
@@ -55,9 +55,10 @@ module Cyclid
     # Sinatra application
     class App < Sinatra::Application
       use Rack::Deflater
-      use Rack::Session::Pool,
+      use Rack::Session::Cookie,
           expire_after: 31_557_600,
-          secret: ENV['COOKIE_SECRET'] || '8f54749dcb0ae0843cdd9669b797d311'
+          secret: ENV['COOKIE_SECRET'] || '8f54749dcb0ae0843cdd9669b797d311',
+          domain: Cyclid.config.domain
       use Rack::Csrf,
           raise: true,
           skip: ['POST:/login',
@@ -65,6 +66,12 @@ module Cyclid
                  'POST:/user/.*/invalidate']
 
       helpers Helpers
+
+      if production?
+        error do
+          redirect to '/'
+        end
+      end
 
       register Sinatra::Flash
 
@@ -146,6 +153,11 @@ module Cyclid
       use Controllers::User
       use Controllers::Health
       use Controllers::Default
+
+      # Catch-all route
+      get '*' do
+        redirect to '/'
+      end
     end
   end
 end

--- a/app/cyclid_ui/config.rb
+++ b/app/cyclid_ui/config.rb
@@ -20,7 +20,7 @@ module Cyclid
   module UI
     # Cyclid UI configuration
     class Config
-      attr_reader :memcached, :log, :server_api, :client_api, :signup
+      attr_reader :memcached, :log, :server_api, :client_api, :signup, :domain
 
       def initialize(path)
         # Try to load the configuration file. If it can't be loaded, we'll
@@ -58,6 +58,9 @@ module Cyclid
 
         # URL of the signup link, if one is defined
         @signup = manage['signup'] || nil
+
+        # Our domain; used when setting cookies
+        @domain = manage['domain'] || nil
       rescue StandardError => ex
         abort "Failed to load configuration file #{path}: #{ex}"
       end

--- a/app/cyclid_ui/controllers/auth.rb
+++ b/app/cyclid_ui/controllers/auth.rb
@@ -65,6 +65,7 @@ module Cyclid
           response.set_cookie('cyclid.token',
                               value: token_data['token'],
                               expires: Time.now + 21_600_000, # +6 hours
+                              domain: Cyclid.config.domain,
                               path: '/',
                               http_only: false) # Must be available for AJAX
 

--- a/app/cyclid_ui/templates/intro.mustache
+++ b/app/cyclid_ui/templates/intro.mustache
@@ -3,7 +3,7 @@
     <div class="col-md-8">
       <h1>Welcome to Cyclid!</h1>
       <p><span style="font-size:140%;">You currently don't belong to any organizations. Without an organization, you won't be able to run any jobs!</span></p>
-      <p>You can either <a href="{{signup}}/organization">create a new organization</a>, or ask someone to add you to an existing organization.</p>
+      <p>You can either <a href="{{signup}}/manage/{{username}}">create a new organization</a>, or ask someone to add you to an existing organization.</p>
       <hr>
       <p>While you're here, there are some useful links which can help you get the most from Cyclid:</p>
       <ul style="line-height: 1.75;">

--- a/spec/controllers/auth_spec.rb
+++ b/spec/controllers/auth_spec.rb
@@ -42,6 +42,7 @@ describe Cyclid::UI::Controllers::Auth do
       allow(config).to receive_message_chain('server_api.host').and_return('example.com')
       allow(config).to receive_message_chain('server_api.port').and_return(9999)
       allow(config).to receive_message_chain('memcached').and_return('example.com:4242')
+      allow(config).to receive_message_chain('domain').and_return(nil)
       allow(Cyclid).to receive(:config).and_return(config)
     end
 


### PR DESCRIPTION
Use Session::Cookie rather than Session::Pool.
Add the "domain" configuration option so that we can set a domain on cookies
that we set.
Set the cookie domain on the JWT token & session cookie.
Redirect errors & unknown routes to /
Update the 'create a new organization' link