### PR TITLE
Change the "Create Org" links

### DIFF
--- a/app/cyclid_ui/templates/layout.mustache
+++ b/app/cyclid_ui/templates/layout.mustache
@@ -51,7 +51,7 @@
                   {{#organization}}
                   <li role="separator" class="divider"></li>
                   {{/organization}}
-                  <li><a href="{{signup}}/organization" target="_blank">Create a new Organization</a></li>
+                  <li><a href="{{signup}}/manage/{{username}}" target="_blank">Manage your Organizations</a></li>
                   {{/signup}}
                 </ul>
               </li>

--- a/app/cyclid_ui/templates/user.mustache
+++ b/app/cyclid_ui/templates/user.mustache
@@ -24,7 +24,7 @@
             <dt>Email</dt><dd id="user_email"></dd>
             <dt>Organizations</dt><dd id="user_org_list"></dd>
             {{#signup}}
-            <dd><a href="{{signup}}/organization" target="_blank">Create a new Organization</a></dd>
+            <dd><a href="{{signup}}/manage/{{username}}" target="_blank">Manage your Organizations</a></dd>
             {{/signup}}
           </div>
         </div>


### PR DESCRIPTION
Rename the "Create new Organization" links to "Manage your Organization" and
change the URL to match the new release of the account management system.